### PR TITLE
Updates for r-devel

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: xaringanthemer
 Title: Custom 'xaringan' CSS Themes
-Version: 0.3.3
+Version: 0.3.4
 Authors@R: 
     person(given = "Garrick",
            family = "Aden-Buie",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -40,6 +40,5 @@ Suggests:
 VignetteBuilder: 
     knitr
 Encoding: UTF-8
-LazyData: true
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.1.1

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# xaringanthemes 0.3.4
+
+* Maintenance release to avoid issues with upcoming R 4.1.0 (#49)
+
 # xaringanthemer 0.3.3
 
 * Add `inverse_link_color` to control color of links on inverse slides

--- a/tests/testthat/helper-session.R
+++ b/tests/testthat/helper-session.R
@@ -3,5 +3,16 @@ with_clean_session <- function(.f, args = list()) {
   dir.create(empty_wd)
   owd <- setwd(empty_wd)
   on.exit({setwd(owd); unlink(empty_wd, TRUE)})
-  callr::r_safe(.f, args)
+  args$.f <- .f
+  res <- callr::r_safe(function(.f, ...) {
+    tryCatch(
+      list(result = .f(...), error = NULL),
+      error = function(e) list(result = NULL, error = e$message)
+    )
+  }, args)
+  if (!is.null(res$error)) {
+    stop(res$error)
+  } else {
+    res$result
+  }
 }

--- a/tests/testthat/test-themes.R
+++ b/tests/testthat/test-themes.R
@@ -106,7 +106,6 @@ test_that("style_xaringan() warns about non-hex colors used by theme_xaringan()"
       options(warn = 2)
       xaringanthemer::style_xaringan(text_color = "rgb(100, 100, 100)", background_color = "white", outfile = NULL)
     }),
-    regexp = "Colors.+used by.+theme_xaringan",
-    class = "callr_status_error"
+    regexp = "Colors.+used by.+theme_xaringan"
   )
 })


### PR DESCRIPTION
- Use alternative method to surface errors from callr::r_safe()
- Don't be lazy about the data

> Please see the problems shown on
> <https://cran.r-project.org/web/checks/check_results_xaringanthemer.html>.
> 
> The errors in r-devel are from recent changes which lock the base
> environment and its namespace, so that one can no longer create new
> bindings there.
> 
> (Which according to the CRAN Policy one never should have done.)
> 
> Please correct before 2021-04-30 to safely retain your package on CRAN.
> 
> Best,
> -k

