### PR TITLE
left-align code by default in template.css

### DIFF
--- a/inst/resources/template.css
+++ b/inst/resources/template.css
@@ -98,6 +98,7 @@ h1, h2, h3 {
 }
 .remark-code {
   font-size: var(--code-font-size);
+  text-align: left;
 }
 .remark-inline-code {
   font-size: var(--code-inline-font-size);{{#code_inline_color}}


### PR DESCRIPTION
I occasionally like to use center-aligned slides, but the problem is that any code chunks (not output) on the slide will also be centered, which doesn't look very code-like (for lack of a better description). This sets the default alignment to left, which is the only alignment that makes sense (right?). 