### PR TITLE
Use logical `NA` that can be cast to character

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # xaringanthemer (development version)
 
+- `scale_xaringan_continuous()` and `scale_xaringan_discrete()` now set
+  `na.value = "grey50"` by default for compatibility with ggplot2 > 3.5.2
+  (thanks @teunbrand, #82).
+
 # xaringanthemer 0.4.3
 
 - Update the spelling of `colour` for compatibility with ggplot2 >= 3.5.1 (@teunbrand #79).

--- a/R/ggplot2.R
+++ b/R/ggplot2.R
@@ -662,7 +662,8 @@ scale_xaringan_continuous <- function(
   color = NULL,
   begin = 0,
   end = 1,
-  inverse = FALSE
+  inverse = FALSE,
+  na.value = NA
 ) {
   requires_package("ggplot2", "scale_xaringan_continuous")
   requires_package("scales", "scale_xaringan_continuous")
@@ -687,6 +688,7 @@ scale_xaringan_continuous <- function(
     palette = scales::gradient_n_pal(colors, values = NULL),
     rescaler = rescaler,
     oob = scales::censor,
+    na.value = na.value,
     ...
   )
 }

--- a/R/ggplot2.R
+++ b/R/ggplot2.R
@@ -663,7 +663,7 @@ scale_xaringan_continuous <- function(
   begin = 0,
   end = 1,
   inverse = FALSE,
-  na.value = NA
+  na.value = "grey50"
 ) {
   requires_package("ggplot2", "scale_xaringan_continuous")
   requires_package("scales", "scale_xaringan_continuous")

--- a/R/ggplot2.R
+++ b/R/ggplot2.R
@@ -596,7 +596,8 @@ scale_xaringan_discrete <- function(
   ...,
   color = NULL,
   direction = 1,
-  inverse = FALSE
+  inverse = FALSE,
+  na.value = "grey50"
 ) {
   requires_package("ggplot2", "scale_xaringan_discrete")
 
@@ -613,7 +614,7 @@ scale_xaringan_discrete <- function(
     )
   }
 
-  ggplot2::discrete_scale(aes_type, "manual", pal, ...)
+  ggplot2::discrete_scale(aes_type, "manual", pal, ..., na.value = na.value)
 }
 
 #' @rdname scale_xaringan

--- a/man/scale_xaringan.Rd
+++ b/man/scale_xaringan.Rd
@@ -42,7 +42,8 @@ scale_xaringan_continuous(
   color = NULL,
   begin = 0,
   end = 1,
-  inverse = FALSE
+  inverse = FALSE,
+  na.value = NA
 )
 
 scale_xaringan_fill_continuous(
@@ -94,6 +95,8 @@ value of \code{inverse_header_color}}
 \item{begin}{Number in the range of \code{[0, 1]} indicating to which point in the color scale the smallest data value should be mapped.}
 
 \item{end}{Number in the range of \code{[0, 1]} indicating to which point in the color scale the largest data value should be mapped.}
+
+\item{na.value}{Color to be used for missing data points.}
 }
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#maturing}{\figure{lifecycle-maturing.svg}{options: alt='[Maturing]'}}}{\strong{[Maturing]}}

--- a/man/scale_xaringan.Rd
+++ b/man/scale_xaringan.Rd
@@ -17,7 +17,8 @@ scale_xaringan_discrete(
   ...,
   color = NULL,
   direction = 1,
-  inverse = FALSE
+  inverse = FALSE,
+  na.value = "grey50"
 )
 
 scale_xaringan_fill_discrete(..., color = NULL, direction = 1, inverse = FALSE)
@@ -92,11 +93,11 @@ reverse the direction, e.g. \code{direction = -1}.}
 color is chosen to work well with the inverse slide styles, namely the
 value of \code{inverse_header_color}}
 
+\item{na.value}{Color to be used for missing data points.}
+
 \item{begin}{Number in the range of \code{[0, 1]} indicating to which point in the color scale the smallest data value should be mapped.}
 
 \item{end}{Number in the range of \code{[0, 1]} indicating to which point in the color scale the largest data value should be mapped.}
-
-\item{na.value}{Color to be used for missing data points.}
 }
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#maturing}{\figure{lifecycle-maturing.svg}{options: alt='[Maturing]'}}}{\strong{[Maturing]}}

--- a/man/scale_xaringan.Rd
+++ b/man/scale_xaringan.Rd
@@ -43,7 +43,7 @@ scale_xaringan_continuous(
   begin = 0,
   end = 1,
   inverse = FALSE,
-  na.value = NA
+  na.value = "grey50"
 )
 
 scale_xaringan_fill_continuous(


### PR DESCRIPTION
Hi there,

We've been preparing a new major release for ggplot2 and found an issue during a reverse dependency check.
The issue surfaced while building the vignette and is caused by increased strictness around types.
Essentially, the `na.value` of a scale should be castable to the palette outcome. The default is `NA_real_` which cannot be cast as character. This PR uses the logical `NA` instead, which can be cast to arbitrary types.

You can test your code with the development version of ggplot2 by installing it as follows:

```r
# install.packages("pak")
pak::pak("tidyverse/ggplot2")
```

We aim to release the new ggplot2 version in about 2 weeks, and hope you can submit a fix to CRAN around that time or let us know when ggplot2 should change. Hopefully this will inform you in a timely manner.

Best wishes,
Teun
