### PR TITLE
fix: Use `after_stat(count)` instead of `..count..`

### DIFF
--- a/vignettes/.gitignore
+++ b/vignettes/.gitignore
@@ -1,2 +1,4 @@
 *.html
 *.R
+
+/.quarto/

--- a/vignettes/ggplot2-themes.Rmd
+++ b/vignettes/ggplot2-themes.Rmd
@@ -21,7 +21,7 @@ knitr::opts_chunk$set(
 img { max-width: 100%; border: none; }
 ```
 
-**xaringanthemer** provides two [ggplot2] themes for your [xaringan] slides 
+**xaringanthemer** provides two [ggplot2] themes for your [xaringan] slides
 to help your data visualizations blend seamlessly into your slides.
 Use `theme_xaringan()` to create plots that match your primary slide style
 or `theme_xaringan_inverse()` to match the style of your inverse slides.
@@ -33,17 +33,17 @@ or `theme_xaringan_inverse()` to match the style of your inverse slides.
 - The ggplot2 themes [uses the colors and themes](#setup-your-theme) from the **xaringanthemer** style functions, if you set your theme inside your slides. Otherwise, it [draws from the `xaringan-themer.css` file](#using-xaringan-themer-css).
 
 - The themes [pick appropriate colors](#colors) for titles, grid lines, and axis text,
-  and also sets the default colors of geoms like `ggplot2::geom_point()` and 
-  `ggplot2::geom_text()`. There are also monotone 
+  and also sets the default colors of geoms like `ggplot2::geom_point()` and
+  `ggplot2::geom_text()`. There are also monotone
   [color and fill scales](#scale-xaringan) based around the primary accent color
   used in your xaringan theme.
 
-- If you use Google Fonts in your slides, the ggplot2 themes use the showtext 
+- If you use Google Fonts in your slides, the ggplot2 themes use the showtext
   package to [automatically match the title and axis text fonts](#fonts)
   of your plots to the heading and text fonts in your xaringan theme.
 
 - I've done my best to set up everything so that _it just works_, but sometimes
-  the showtext package adds a bit of complication to the routine data 
+  the showtext package adds a bit of complication to the routine data
   visualization workflow. At the end of this vignette I include
   [a few tips](#tips) for working with showtext.
 
@@ -57,7 +57,7 @@ that results in the xaringan theme previewed in the slides above.
 
 I've also picked out a few fonts from [Google Fonts][google-fonts]
 that I would probably never use in a real presentation,
-but they're flashy enough to make it easy to see 
+but they're flashy enough to make it easy to see
 that we're not using the standard default fonts.
 
 ````markdown
@@ -89,7 +89,7 @@ style_mono_accent(
 )
 ```
 
-If you use a hidden chunk like this one 
+If you use a hidden chunk like this one
 inside your slides' R Markdown source file,
 `theme_xaringan()` will know which colors and fonts you've picked.
 
@@ -126,7 +126,7 @@ To restore the previous default colors of ggplot2 geoms, call
 theme_xaringan_restore_defaults()
 ```
 
-Add `theme_xaringan_inverse()` to automatically create a plot 
+Add `theme_xaringan_inverse()` to automatically create a plot
 that matches the inverse slide style.
 
 ```{r ggplot2-demo-inverse, fig.show="hide"}
@@ -144,7 +144,7 @@ you might want to use the theme's CSS file for new presentations
 instead of rebuilding your theme with every new slide deck.
 
 In these cases, `theme_xaringan()` will look for a CSS file
-written by **xaringanthemer** in your slides' directory 
+written by **xaringanthemer** in your slides' directory
 or in a sub-folder under the same directory
 that it can use to determine the colors and fonts used in your slides.
 
@@ -152,7 +152,7 @@ If you happen to have multiple slide themes
 written by **xaringanthemer** in the same directory,
 the one named `xaringan-themer.css` will be used.
 If xaringanthemer picks the wrong file,
-you can use the `css_file` in `theme_xaringan()` 
+you can use the `css_file` in `theme_xaringan()`
 to specify exactly which CSS file to use.
 
 ```{r eval=FALSE}
@@ -167,7 +167,7 @@ while maintaining a consistent look and feel or brand.
 
 Finally, you don't even need a xaringanthemer CSS file.
 You can specify the key ingredients for the theme
-as arguments to `theme_xaringan()`, namely 
+as arguments to `theme_xaringan()`, namely
 text, background, and accent colors as well as text and title fonts.
 
 The R chunk below replicated the demonstrated theme,
@@ -187,10 +187,10 @@ theme_xaringan(
 
 ## Colors
 
-As demonstrated above, 
+As demonstrated above,
 `theme_xaringan()` and `theme_xaringan_inverse()`
 modify the default colors and fonts of geometries.
-This means that `geom_point()`, `geom_bar()`, `geom_text()` 
+This means that `geom_point()`, `geom_bar()`, `geom_text()`
 and other geoms used in your plots
 will reasonably match your slide themes with no extra work.
 
@@ -205,7 +205,7 @@ g_diamonds + theme_xaringan()
 
 Whenever `theme_xaringan()` or `theme_xaringan_inverse()` are called,
 the default values of many of ggplot2 geoms are set by default.
-You can opt out of this by setting `set_ggplot_defaults = FALSE` 
+You can opt out of this by setting `set_ggplot_defaults = FALSE`
 when using either theme.
 You can also restore the geom aesthetic defaults to their original values
 before the first time `theme_xaringan()` or `theme_xaringan_inverse()`
@@ -219,7 +219,7 @@ theme_xaringan_restore_defaults()
 
 xaringanthemer includes monotone color and fill scales
 to match your ggplot2 theme.
-The scale functions all follow the naming pattern 
+The scale functions all follow the naming pattern
 `scale_xaringan_<aes>_<data_type>()`,
 where `<aes>` is replaced with either `color` or `fill`
 and `<data_type>` is one of `discrete` or `continuous`.
@@ -232,13 +232,13 @@ by setting the argument `inverse = TRUE`.
 
 ```{r scale-xaringan, fig.width = 9, fig.height = 5, out.width="48%", fig.show="hold", echo = TRUE}
 ggplot(diamonds, aes(x = cut)) +
-  geom_bar(aes(fill = ..count..), show.legend = FALSE) +
+  geom_bar(aes(fill = after_stat(count)), show.legend = FALSE) +
   labs(x = NULL, y = "Count", title = "Diamond Cut Quality") +
   theme_xaringan() +
   scale_xaringan_fill_continuous()
 
 ggplot(mpg, aes(x = hwy, y = cty)) +
-  geom_count(aes(color = ..n..), show.legend = FALSE) +
+  geom_count(aes(color = after_stat(n)), show.legend = FALSE) +
   labs(x = "Highway MPG", y = "City MPG", title = "Fuel Efficiency") +
   theme_xaringan_inverse() +
   scale_xaringan_color_continuous(breaks = seq(3, 12, 2), inverse = TRUE, begin = 1, end = 0)
@@ -257,9 +257,9 @@ The scales come with a few more options:
 
 - Choose a different primary color using the `color` argument.
 
-- Use the inverse color slide theme color with `inverse = TRUE` 
+- Use the inverse color slide theme color with `inverse = TRUE`
   (only applies when `color` is not supplied).
-  
+
 - Invert the direction of the discrete scales with `direction = -1`.
 
 - Control the range of the continuous color scale used with `begin` and `end`.
@@ -274,7 +274,7 @@ xaringanthemer uses the [showtext] and [sysfonts] packages by Yixuan Qiu
 to automatically download and register [Google Fonts][google-fonts]
 for use with your ggplot2 plots.
 
-In your slide theme, 
+In your slide theme,
 use the `<type>_font_google` argument
 with the `google_font("<font name>")` helper
 (or the default xaringanthemer fonts)
@@ -287,7 +287,7 @@ In our demo theme, we used `style_mono_accent()` with
 ```{r text demo, fig.width = 10}
 g_diamonds_with_text <-
   g_diamonds +
-  geom_text(aes(y = ..count.., label = format(..count.., big.mark = ",")),
+  geom_text(aes(y = after_stat(count), label = format(after_stat(count), big.mark = ",")),
     vjust = -0.30, size = 8, stat = "count") +
   labs(x = "Cut", y = "Count")
 
@@ -317,7 +317,7 @@ If you want to use a font that isn't in the Google Fonts collection,
 you need to manually register the font with sysfonts
 so that it can be used in your plots.
 
-I found a nice open source font called 
+I found a nice open source font called
 [Glacial Indifference](https://fontlibrary.org/en/font/glacial-indifference)
 by Alfredo Marco Pradil
 available at [fontlibrary.org](https://fontlibrary.org).
@@ -374,16 +374,16 @@ g_diamonds_with_text +
 ## Tips for using the showtext package {#tips}
 
 Working with fonts is notoriously frustrating,
-but [showtext] and [sysfonts] do a great job ensuring that 
+but [showtext] and [sysfonts] do a great job ensuring that
 Google Fonts and custom fonts work on all platforms.
-As you've seen in the examples above, 
+As you've seen in the examples above,
 the process is mostly seamless,
-but there are a few caveats and 
+but there are a few caveats and
 places where the methods used by these packages may interrupt a typical ggplot2 workflow.
 
 ### R Markdown
 
-To use the showtext package in R Markdown, 
+To use the showtext package in R Markdown,
 knitr requires that the `fig.showtext` chunk option be set to `TRUE`,
 either in the chunk producing the figure or globally in the document.
 
@@ -394,7 +394,7 @@ When this happens,
 xaringanthemer will produce an error:
 
 ```
-Error in verify_fig_showtext(fn) : 
+Error in verify_fig_showtext(fn) :
   To use theme_xaringan_base() with knitr, you need to set the chunk
   option `fig.showtext = TRUE` for this chunk. Or you can set this option
   globally with `knitr::opts_chunk$set(fig.showtext = TRUE)`.
@@ -411,7 +411,7 @@ follow the instructions and choose one of the two suggestions:
 ### MacOS
 
 On MacOS, you'll need to have `xquartz` installed for `sysfonts` to work properly.
-If you use [homebrew](https://brew.sh/), 
+If you use [homebrew](https://brew.sh/),
 you can install `xquartz` with
 
 ```bash


### PR DESCRIPTION
Fixes deprecated usage of `..count..` and `..n..` in the ggplot2 vignette

```r
ggplot(diamonds, aes(x = cut)) +
  geom_bar(aes(fill = ..count..), show.legend = FALSE) +
  scale_xaringan_fill_continuous(na.value = NA)
#> Warning: The dot-dot notation (`..count..`) was deprecated in ggplot2 3.4.0.
#> ℹ Please use `after_stat(count)` instead.
#> This warning is displayed once every 8 hours.
#> Call `lifecycle::last_lifecycle_warnings()` to see where this warning was
#> generated.
```